### PR TITLE
Configure testbed device traffic using offered load

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The configuration YAML file should necessarily have the following format/fields:
 ```yaml
 device_list: [33, 26] # List of device IDs
 experiment_time_sec: 10 # Experiment time in seconds
-transmit_interval_msec: 200 # Average time interval between consecutive transmissions from each device
+offered_load_percent: 80 # Aggregate network offered load
 packet_size_bytes: 16
 mac_protocol: "csma" # MAC protocol used by the devices
 packet_arrival_model: "poisson" # Packet generation model used by the devices.

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -1,8 +1,8 @@
 device_list: [33, 26] # List of device IDs
 experiment_time_sec: 10 # Experiment time in seconds
-transmit_interval_msec: 200 # Average time interval between consecutive transmissions from each device
+offered_load_percent: 80 # Aggregate network offered load
 packet_size_bytes: 16
-mac_protocol: "csma" # MAC protocol used by the devices
+mac_protocol: "aloha" # MAC protocol used by the devices
 packet_arrival_model: "poisson" # Packet generation model used by the devices.
 # PHY layer parameters
 transmit_SF: "SF8" # Spreading factor

--- a/loratestbed/main_controller.py
+++ b/loratestbed/main_controller.py
@@ -1,13 +1,14 @@
 import argparse
 import logging
+
+logger = logging.getLogger(__name__)
 import pdb
 import time
 import yaml
 
 from loratestbed.controller import SerialInterface
 from loratestbed.device_manager import DeviceManager
-from loratestbed.main_gateway import run_gateway
-from loratestbed.experiment_logbook import logbook_add_entry
+from loratestbed.utils import get_transmit_interval_msec
 
 
 def make_parser():
@@ -22,6 +23,21 @@ def make_parser():
 def load_config(yaml_path):
     with open(yaml_path, "r") as f:
         config = yaml.safe_load(f)
+
+    # Compute interval from offered load
+    transmit_interval_msec = get_transmit_interval_msec(
+        len(config["device_list"]),
+        config["offered_load_percent"],
+        config["packet_size_bytes"],
+        config["transmit_SF"],
+        config["transmit_BW"],
+        config["transmit_CR"],
+    )
+    config["transmit_interval_msec"] = transmit_interval_msec
+    logger.info(
+        f"Interval is {transmit_interval_msec} ms for {config['offered_load_percent']}% load and {len(config['device_list'])} devices"
+    )
+
     return config
 
 
@@ -42,10 +58,10 @@ def run_controller(port, config):
     config = load_config(config)
 
     interface = SerialInterface(port)
-    logging.info("Setting up DeviceManager")
+    logger.info("Setting up DeviceManager")
     device_manager = DeviceManager(config["device_list"], interface)
 
-    # TODO: fix this
+    # TODO: fix this?
     # device_manager.update_node_params(
     #     EXPT_TIME=[experiment_time_sec],
     #     # TX_INTERVAL=[transmit_interval_msec],
@@ -55,70 +71,69 @@ def run_controller(port, config):
     #     LORA_BW=[transmit_BW, receive_BW],
     #     # LORA_CR=[transmit_CR, receive_CR],
     # )
+    # device_manager.update_node_params(**config)
 
     device_manager.disable_all_devices()
 
     # pre-experiment: updating parameters
-    logging.info(f"Setting experiment time to {config['experiment_time_sec']} seconds")
+    logger.info(f"Setting experiment time to {config['experiment_time_sec']} seconds")
     device_manager._set_experiment_time_seconds(config["experiment_time_sec"])
 
-    # device_manager.update_node_params(**config)
-
-    logging.info(
+    logger.info(
         f"Setting transmit interval time to {config['transmit_interval_msec']} milliseconds"
     )
     device_manager._set_transmit_interval_milliseconds(config["transmit_interval_msec"])
 
-    logging.info(
+    logger.info(
         f"Setting scheduler transmit interval mode to {config['packet_arrival_model']}"
     )
     device_manager._set_packet_arrival_model(config["packet_arrival_model"])
 
-    logging.info(
+    logger.info(
         f"Setting transmit SF to {config['transmit_SF']} and receive SF to {config['receive_SF']}"
     )
     device_manager._set_transmit_and_receive_SF(
         config["transmit_SF"], config["receive_SF"]
     )
 
-    logging.info(
+    logger.info(
         f"Setting transmit BW to {config['transmit_BW']} and receive BW to {config['receive_BW']}"
     )
     device_manager._set_transmit_and_receive_BW(
         config["transmit_BW"], config["receive_BW"]
     )
 
-    logging.info(
+    logger.info(
         f"Setting transmit CR to {config['transmit_CR']} and receive CR to {config['receive_CR']}"
     )
     device_manager._set_transmit_and_receive_CR(
         config["transmit_CR"], config["receive_CR"]
     )
 
-    logging.info(f"Setting packet size to {config['packet_size_bytes']} bytes")
+    logger.info(f"Setting packet size to {config['packet_size_bytes']} bytes")
     device_manager.set_packet_size_bytes(config["packet_size_bytes"])
 
-    logging.info(f"Setting MAC protocol to {config['mac_protocol']}")
+    logger.info(f"Setting MAC protocol to {config['mac_protocol']}")
     device_manager.set_mac_protocol(config["mac_protocol"])
 
     # %% running experiment
-    logging.info("Triggering all devices")
+    logger.info("Triggering all devices")
     device_manager.trigger_all_devices()
 
-    logging.info("Waiting for experiment to finish...")
+    logger.info("Waiting for experiment to finish...")
     time.sleep(config["experiment_time_sec"] + 10)
 
     # post-experiment: pinging devices and get results
-    logging.info("Pinging devices")
+    logger.info("Pinging devices")
     pingable_devices = device_manager._ping_devices(config["device_list"])
     assert (
         pingable_devices == config["device_list"]
     ), "Not all devices responded to ping"
 
-    logging.info("Reading all result registers")
+    logger.info("Reading all result registers")
     result_df = device_manager.results()
 
-    logging.debug(f"{result_df}")
+    logger.debug(f"{result_df}")
 
     return result_df, config
 

--- a/loratestbed/utils.py
+++ b/loratestbed/utils.py
@@ -1,3 +1,6 @@
+import math
+
+
 def uint8_to_bytes(value: int) -> bytes:
     # assert value >= 0 and value <= 255
 
@@ -12,3 +15,88 @@ def uint8_to_bytes(value: int) -> bytes:
 def bytes_to_uint8(data: bytes) -> int:
     assert len(data) == 1, "Data must be 1 byte long"
     return int.from_bytes(data, byteorder="big", signed=False)
+
+
+def comp_lora_airtime(PL, SF, CRC, IH, DE, CR, SR, NS):
+    """
+    Compute Airtime of LoRa (from SX1276 datasheet)
+    PL: number of payload bytes
+    SF: spreading factor
+    CRC: presence of a CRC (0 if absent, 1 if present)
+    IH: whether the header is enabled (0 if enabled, 1 if disabled)
+    DE: whether low data rate optimization is on (0 if disabled, 1 if enabled)
+    CR: the coding rate (1 meaning 4/5 rate, 4 meaning 4/8 rate)
+    SR: Sampling Rate
+    NS: Number of samples per chirp at sample rate
+    """
+    max_inp_1 = math.ceil(
+        (8 * PL - 4 * SF + 28 + 16 * CRC - 20 * IH) / (4 * (SF - 2 * DE))
+    ) * (CR + 4)
+    max_inp_2 = 0
+    max_val = max(max_inp_1, max_inp_2)
+
+    n_pb = 8 + max_val
+
+    air_time = NS * (n_pb + 12.25) / SR
+
+    return air_time
+
+
+def compute_packet_time(payload_bytes: int, sf: int, bw_str: str, cr_str: str):
+    """_summary_
+
+    Args:
+        payload_bytes (int): _description_
+        sf (int): _description_
+        bw_str (str): _description_
+        cr_str (str): _description_
+
+    Raises:
+        ValueError: _description_
+
+    Returns:
+        _type_: _description_
+    """
+    bw_khz = float(bw_str[2:])
+
+    if cr_str == "CR_4_8":
+        cr = 4
+    elif cr_str == "CR_4_5":
+        cr = 1
+    else:
+        raise ValueError(f"Invalid CR value {cr_str}")
+
+    num_samples_per_chirp = 2**sf
+    sampling_rate = bw_khz * 1000
+
+    packet_time_sec = comp_lora_airtime(
+        payload_bytes, sf, 1, 0, 0, cr, sampling_rate, num_samples_per_chirp
+    )
+
+    return packet_time_sec
+
+
+def get_transmit_interval_msec(
+    num_devices: int,
+    offered_load_percent: float,
+    packet_size_bytes: int,
+    transmit_SF: int,
+    transmit_BW: int,
+    transmit_CR: str,
+):
+    packet_time_sec: float = compute_packet_time(
+        packet_size_bytes, transmit_SF, transmit_BW, transmit_CR
+    )
+
+    assert (
+        offered_load_percent > 0
+    ), f"Offered load must be greater than zero: {offered_load_percent}"
+
+    max_pack_per_sec: float = 1 / packet_time_sec
+    net_pack_per_sec: float = max_pack_per_sec * offered_load_percent / 100
+    net_pack_per_sec_per_device: float = net_pack_per_sec / float(num_devices)
+
+    transmit_interval_sec: float = 1 / net_pack_per_sec_per_device
+    transmit_interval_msec: int = int(transmit_interval_sec * 1000)
+
+    return transmit_interval_msec

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,4 @@
-from loratestbed.metrics import read_packet_trace, metrics_from_trace, print_statistics
+from loratestbed.metrics import read_packet_trace, extract_required_metrics_from_trace
 import os
 import logging
 import pdb
@@ -21,19 +21,3 @@ def test_read_packet_trace():
     packet_trace = read_packet_trace(FULL_PATH_FILENAME)
 
     print(packet_trace)
-
-
-def test_metrics():
-    packet_trace = read_packet_trace(FULL_PATH_FILENAME)
-
-    missing_pack_dict = {25: 30, 26: 14, 28: 18, 29: 15, 32: 44, 34: 16}
-
-    total_pack_dict = {25: 60, 26: 60, 28: 60, 29: 60, 32: 60, 34: 60}
-
-    metrics = metrics_from_trace(packet_trace, total_pack_dict)
-    print()
-    print(f"Node ID  | Missing")
-    for node_id in metrics:
-        missing_packets = metrics[node_id]["MissingPackets"]
-        print(f"{node_id}  | {missing_packets}")
-        assert missing_packets == missing_pack_dict[node_id]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,9 @@
-from loratestbed.utils import uint8_to_bytes, bytes_to_uint8
+from loratestbed.utils import (
+    uint8_to_bytes,
+    bytes_to_uint8,
+    compute_packet_time,
+    get_transmit_interval_msec,
+)
 
 
 def test_uint8_to_bytes():
@@ -18,3 +23,42 @@ def test_uint8_to_bytes():
 def test_uint8_two_way():
     for i in range(0, 256):
         assert bytes_to_uint8(uint8_to_bytes(i)) == i
+
+
+def test_transmit_interval():
+    packet_size_bytes = 16
+    sf_val = 8
+    bw_str = "BW125"
+    cr_str = "CR_4_8"
+
+    print()
+
+    interval_4_dev_100pc = get_transmit_interval_msec(
+        4, 100, packet_size_bytes, sf_val, bw_str, cr_str
+    )
+    interval_4_dev_10pc = get_transmit_interval_msec(
+        4, 10, packet_size_bytes, sf_val, bw_str, cr_str
+    )
+    interval_40_dev_100pc = get_transmit_interval_msec(
+        40, 100, packet_size_bytes, sf_val, bw_str, cr_str
+    )
+    interval_40_dev_10pc = get_transmit_interval_msec(
+        40, 10, packet_size_bytes, sf_val, bw_str, cr_str
+    )
+
+    assert interval_4_dev_100pc == int(interval_4_dev_10pc / 10)
+    assert interval_40_dev_100pc == int(interval_40_dev_10pc / 10)
+    assert interval_4_dev_100pc == int(interval_40_dev_100pc / 10)
+
+    transmit_interval_msec = get_transmit_interval_msec(
+        10,
+        100,
+        packet_size_bytes,
+        sf_val,
+        bw_str,
+        cr_str,
+    )
+
+    print(
+        f"10 devices, {packet_size_bytes} byte payload, [SF{sf_val}|{bw_str}|{cr_str}] \nOffered load: {100}%, Transmit interval: {transmit_interval_msec} msec"
+    )


### PR DESCRIPTION
Traffic arrival intervals from testbed devices is now based on aggregate network offered load. The inter-packet arrival time on a per device basis is computed based on the config. Until now, the inter-packet arrival time had to be set manually.