### PR TITLE
Use offered load correctly while computing results

### DIFF
--- a/loratestbed/device_manager.py
+++ b/loratestbed/device_manager.py
@@ -113,7 +113,6 @@ class DeviceManager:
 
     def _message_to_device(self, device_idx: int, message: List[int]):
         # check if device_idx is valid
-        time.sleep(0.1)
         if device_idx not in self._device_idxs and device_idx != 255:
             self._logger.warning(f"Device index {device_idx} not in list of devices")
             return None

--- a/loratestbed/main_controller.py
+++ b/loratestbed/main_controller.py
@@ -25,7 +25,7 @@ def load_config(yaml_path):
         config = yaml.safe_load(f)
 
     # Compute interval from offered load
-    transmit_interval_msec = get_transmit_interval_msec(
+    transmit_interval_msec, packet_airtime_sec = get_transmit_interval_msec(
         len(config["device_list"]),
         config["offered_load_percent"],
         config["packet_size_bytes"],
@@ -33,6 +33,7 @@ def load_config(yaml_path):
         config["transmit_BW"],
         config["transmit_CR"],
     )
+    config["packet_airtime_sec"] = packet_airtime_sec
     config["transmit_interval_msec"] = transmit_interval_msec
     logger.info(
         f"Interval is {transmit_interval_msec} ms for {config['offered_load_percent']}% load and {len(config['device_list'])} devices"

--- a/loratestbed/utils.py
+++ b/loratestbed/utils.py
@@ -84,6 +84,19 @@ def get_transmit_interval_msec(
     transmit_BW: int,
     transmit_CR: str,
 ):
+    """_summary_
+
+    Args:
+        num_devices (int): _description_
+        offered_load_percent (float): _description_
+        packet_size_bytes (int): _description_
+        transmit_SF (int): _description_
+        transmit_BW (int): _description_
+        transmit_CR (str): _description_
+
+    Returns:
+        _type_: _description_
+    """
     packet_time_sec: float = compute_packet_time(
         packet_size_bytes, transmit_SF, transmit_BW, transmit_CR
     )
@@ -99,4 +112,4 @@ def get_transmit_interval_msec(
     transmit_interval_sec: float = 1 / net_pack_per_sec_per_device
     transmit_interval_msec: int = int(transmit_interval_sec * 1000)
 
-    return transmit_interval_msec
+    return transmit_interval_msec, packet_time_sec

--- a/loratestbed/utils.py
+++ b/loratestbed/utils.py
@@ -42,7 +42,7 @@ def comp_lora_airtime(PL, SF, CRC, IH, DE, CR, SR, NS):
     return air_time
 
 
-def compute_packet_time(payload_bytes: int, sf: int, bw_str: str, cr_str: str):
+def compute_packet_time(payload_bytes: int, sf_str: str, bw_str: str, cr_str: str):
     """_summary_
 
     Args:
@@ -57,20 +57,21 @@ def compute_packet_time(payload_bytes: int, sf: int, bw_str: str, cr_str: str):
     Returns:
         _type_: _description_
     """
-    bw_khz = float(bw_str[2:])
+    bw_khz: float = float(bw_str[2:])
+    sf_int: int = int(sf_str[2:])
 
     if cr_str == "CR_4_8":
-        cr = 4
+        cr: int = 4
     elif cr_str == "CR_4_5":
-        cr = 1
+        cr: int = 1
     else:
         raise ValueError(f"Invalid CR value {cr_str}")
 
-    num_samples_per_chirp = 2**sf
-    sampling_rate = bw_khz * 1000
+    num_samples_per_chirp: int = 2**sf_int
+    sampling_rate: float = bw_khz * 1000
 
-    packet_time_sec = comp_lora_airtime(
-        payload_bytes, sf, 1, 0, 0, cr, sampling_rate, num_samples_per_chirp
+    packet_time_sec: float = comp_lora_airtime(
+        payload_bytes, sf_int, 1, 0, 0, cr, sampling_rate, num_samples_per_chirp
     )
 
     return packet_time_sec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "loratestbed"
-version = "0.1.1"
+version = "0.1.8"
 description = ""
 authors = [
     "Raghav Subbaraman <rsubbaraman@eng.ucsd.edu>",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,7 @@ def test_uint8_two_way():
 
 def test_transmit_interval():
     packet_size_bytes = 16
-    sf_val = 8
+    sf_val = "SF8"
     bw_str = "BW125"
     cr_str = "CR_4_8"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,16 +33,16 @@ def test_transmit_interval():
 
     print()
 
-    interval_4_dev_100pc = get_transmit_interval_msec(
+    interval_4_dev_100pc, _ = get_transmit_interval_msec(
         4, 100, packet_size_bytes, sf_val, bw_str, cr_str
     )
-    interval_4_dev_10pc = get_transmit_interval_msec(
+    interval_4_dev_10pc, _ = get_transmit_interval_msec(
         4, 10, packet_size_bytes, sf_val, bw_str, cr_str
     )
-    interval_40_dev_100pc = get_transmit_interval_msec(
+    interval_40_dev_100pc, _ = get_transmit_interval_msec(
         40, 100, packet_size_bytes, sf_val, bw_str, cr_str
     )
-    interval_40_dev_10pc = get_transmit_interval_msec(
+    interval_40_dev_10pc, _ = get_transmit_interval_msec(
         40, 10, packet_size_bytes, sf_val, bw_str, cr_str
     )
 
@@ -50,7 +50,7 @@ def test_transmit_interval():
     assert interval_40_dev_100pc == int(interval_40_dev_10pc / 10)
     assert interval_4_dev_100pc == int(interval_40_dev_100pc / 10)
 
-    transmit_interval_msec = get_transmit_interval_msec(
+    transmit_interval_msec, _ = get_transmit_interval_msec(
         10,
         100,
         packet_size_bytes,


### PR DESCRIPTION
Offered load and packet size in bytes are now correctly used
while computing metrics. Until now, these values were computed
wrongly and/or hardcoded.

Other bugfixes.

Fixes #12 